### PR TITLE
Improve printing of optim rounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScoreDrivenModels"
 uuid = "4a87933e-d659-11e9-0e65-7f40dedd4a3a"
 authors = ["guilhermebodin <guilherme.b.moraes@gmail.com>, raphaelsaavedra <raphael.saavedra93@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/MLE.jl
+++ b/src/MLE.jl
@@ -131,7 +131,7 @@ function fit!(gas::ScoreDrivenModel{D, T}, y::Vector{T};
                                                         opt_method.initial_points[i])
             opt_result = optimize(func, opt_method, verbose, i, time_limit_sec)
             update_aux_estimation!(aux_est, func, opt_result)
-            verbose >= 1 && println("Round $i of $n_initial_points - Log-likelihood: $(-opt_result.minimum * length(y))")
+            verbose >= 1 && println("Round $i of $n_initial_points: log-likelihood = $(-opt_result.minimum * length(y))")
         catch err
             println(err)
             if throw_errors


### PR DESCRIPTION
Replacing `-` to avoid confusions, as people might think the negative log-likelihood is being shown